### PR TITLE
Send back parseable output from enqueue

### DIFF
--- a/lib/gt_bridge/http/router.ex
+++ b/lib/gt_bridge/http/router.ex
@@ -32,6 +32,6 @@ defmodule GtBridge.Http.Router do
     IO.puts(body)
 
     conn
-    |> send_resp(200, "")
+    |> send_resp(200, "{}")
   end
 end

--- a/lib/gt_bridge/http/router.ex
+++ b/lib/gt_bridge/http/router.ex
@@ -4,6 +4,7 @@ defmodule GtBridge.Http.Router do
   def call(conn, config) do
     conn
     |> assign(:pharo_client, config[:pharo_client])
+    |> assign(:eval, config[:eval])
     |> put_resp_content_type("application/json")
     |> super(config)
   end
@@ -30,6 +31,12 @@ defmodule GtBridge.Http.Router do
   post "/ENQUEUE" do
     {:ok, body, conn} = Plug.Conn.read_body(conn)
     IO.puts(body)
+
+    if body["statements"] != "" do
+      eval = conn.assigns.eval
+      result = GenServer.call(eval, {:eval, body["statements"]})
+      IO.puts(result)
+    end
 
     conn
     |> send_resp(200, "{}")

--- a/lib/gt_bridge/http/supervisor.ex
+++ b/lib/gt_bridge/http/supervisor.ex
@@ -7,11 +7,13 @@ defmodule GtBridge.Http.Supervisor do
   end
 
   def start_listener(port_server, port_client) do
+    eval = Process.whereis(:eval)
+
     DynamicSupervisor.start_child(
       __MODULE__,
       {Plug.Cowboy,
        scheme: :http,
-       plug: {GtBridge.Http.Router, %{pharo_client: port_client}},
+       plug: {GtBridge.Http.Router, %{pharo_client: port_client, eval: eval}},
        port: port_server}
     )
   end

--- a/lib/gt_bridge/supervisor.ex
+++ b/lib/gt_bridge/supervisor.ex
@@ -7,7 +7,11 @@ defmodule GtBridge.Supervisor do
 
   @impl true
   def init(_args) do
-    children = [{EvaluationSupervisor, []}, {Tcp.Supervisor, []}, {GtBridge.Http.Supervisor, []}]
+    children = [{EvaluationSupervisor, [{Eval, name: :eval}]}, {Tcp.Supervisor, []}, {GtBridge.Http.Supervisor, []}]
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  def eval(statements) do
+    Eval.eval(pid, statements)
   end
 end


### PR DESCRIPTION
This ensures we send back an empty object on `ENQUEUE` commands, meaning we can continue from there. This will ensure we don’t fail on startup. No other enqueueing logic was changed thus far, meaning that if we actually try to execute anything, we will block.

Cheers