### PR TITLE
Handle the tcp_closed message

### DIFF
--- a/lib/tcp/connection.ex
+++ b/lib/tcp/connection.ex
@@ -94,6 +94,10 @@ defmodule Tcp.Connection do
     {:noreply, state}
   end
 
+  def handle_info({:tcp_closed, _port}, state) do
+    {:stop, :normal, state}
+  end
+
   ############################################################
   #                           Helpers                        #
   ############################################################


### PR DESCRIPTION
This would sometimes screw up examples when the TCP server dies with:

```elixir
17:22:09.569 [error] GenServer #PID<0.272.0> terminating ** (FunctionClauseError) no function clause matching in Tcp.Connection.handle_info/2
    (gt_bridge 0.3.0) lib/tcp/connection.ex:92: Tcp.Connection.handle_info({:tcp_closed, #Port<0.13>}, %Tcp.Connection{inferior: #PID<0.276.0>, socket: #Port<0.13>})
    (stdlib 6.1) gen_server.erl:2345: :gen_server.try_handle_info/3
    (stdlib 6.1) gen_server.erl:2433: :gen_server.handle_msg/6
    (stdlib 6.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
Process Label: Tcp.Connection
Last message: {:tcp_closed, #Port<0.13>}
State: %Tcp.Connection{inferior: #PID<0.276.0>, socket: #Port<0.13>}
```