### PR TITLE
Change Eval to be robust upon error

### DIFF
--- a/lib/eval.ex
+++ b/lib/eval.ex
@@ -54,14 +54,15 @@ defmodule Eval do
       unique_keys = Keyword.merge(state.bindings, Keyword.delete(new_bindings, :port))
 
       {:reply, term, %__MODULE__{state | bindings: unique_keys}}
-    rescue
-      e ->
+    catch
+      kind, e ->
         # Replace this with a proper eval strategy reply wise, it
         # isn't proper that we are manually calling notify here,
         # assumes too much context
-        Code.eval_string(
-          "Eval.notify(#{inspect({e, __STACKTRACE__})}, command_id, port)",
-          state.bindings ++ [command_id: command_id]
+        notify(
+          {:error, Exception.format_stacktrace(__STACKTRACE__)},
+          command_id,
+          state.bindings[:port]
         )
 
         {:reply, e, state}


### PR DESCRIPTION
Before the previous technique would actual cause the evaluator to crash, running it from gt would obscure the fact as GT would just error out.

However running it before gives:

```elixir
  iex(anoma@YU-NO)103> Eval.eval(:eval, ":sys.get_state(self())", 2)
** (exit) exited in: GenServer.call(:eval, {:eval, ":sys.get_state(self())", 2}, 5000)
    ** (EXIT) an exception was raised:
        ** (TokenMissingError) token missing on nofile:1:635:
    error: missing terminator: ]
    │
  1 │ Eval.notify({{:calling_self, {:sys, :get_state, [#PID<0.8987.0>]}}, [{:sys, :send_system_msg, 2, [file: ~c"sys.erl", line: 754]}, {:sys, :get_state, 1, [file: ~c"sys.erl", line: 343]}, {:elixir_eval, :__FILE__, 1, [file: ~c"nofile", line: 1]}, {:elixir, :eval_external_handler, 3, [file: ~c"src/elixir.erl", line: 386]}, {:erl_eval, :do_apply, 7, [file: ~c"erl_eval.erl", line: 904]}, {:elixir, :eval_forms, 4, [file: ~c"src/elixir.erl", line: 364]}, {Module.ParallelChecker, :verify, 1, [file: ~c"lib/module/parallel_checker.ex", line: 120]}, {Code, :validated_eval_string, 3, [file: ~c"lib/code.ex", line: 572]}]}, command_id, port)
```

However now it properly returns, meaning the GT gets a tuple back, we should improve the resulting error in a further topic so it can be dispatched upon.