### PR TITLE
Guard struct completion against non-charlist cursor contexts

### DIFF
--- a/lib/examples/e_completion.ex
+++ b/lib/examples/e_completion.ex
@@ -59,6 +59,21 @@ defmodule Examples.ECompletion do
     results
   end
 
+  @spec complete_struct_non_alias() :: [String.t()]
+  def complete_struct_non_alias() do
+    # cursor_context wraps these struct names in nested context tuples, not a
+    # plain charlist. We still complete the ones we know: the %__MODULE__
+    # special form and structs under a dotted alias (%File. -> %File.Stat).
+    assert Completion.complete("%__MOD") == ["%__MODULE__"]
+    assert "%File.Stat" in Completion.complete("%File.")
+
+    # Shapes with no known struct name complete to nothing (and never crash).
+    assert Completion.complete("%@foo") == []
+    assert Completion.complete("%foo.bar") == []
+
+    Completion.complete("%__MOD")
+  end
+
   @spec complete_empty_returns_something() :: [String.t()]
   def complete_empty_returns_something() do
     results = Completion.complete("is_")

--- a/lib/gt_bridge/completion.ex
+++ b/lib/gt_bridge/completion.ex
@@ -42,7 +42,7 @@ defmodule GtBridge.Completion do
         complete_local_or_var(List.to_string(hint), bindings)
 
       {:struct, hint} ->
-        complete_struct(List.to_string(hint))
+        complete_struct(struct_prefix(hint))
 
       :expr ->
         complete_local_or_var("", bindings)
@@ -143,16 +143,45 @@ defmodule GtBridge.Completion do
     |> Enum.sort()
   end
 
-  defp complete_struct(hint) do
-    for {module, _} <- :code.all_loaded(),
-        name = Atom.to_string(module),
-        String.starts_with?(name, "Elixir."),
-        short = String.replace_prefix(name, "Elixir.", ""),
-        String.starts_with?(short, hint),
-        function_exported?(module, :__struct__, 1) do
-      short
-    end
-    |> Enum.sort()
+  # 0-arity Kernel special forms (__MODULE__, __ENV__, ...) can stand where a
+  # struct name goes, e.g. %__MODULE__{}. Offer them from the language itself
+  # rather than naming any one.
+  @special_forms for {name, 0} <- Kernel.SpecialForms.__info__(:macros),
+                     do: Atom.to_string(name)
+
+  # cursor_context wraps the struct name in the same context tuples it uses
+  # elsewhere: a charlist alias (%MapS), a dotted alias (%File.), or a
+  # local_or_var for a special form like %__MODULE__. Flatten each to the
+  # prefix string complete_struct/1 matches on; anything else has no struct
+  # name to complete.
+  @spec struct_prefix(charlist() | tuple()) :: String.t() | nil
+  defp struct_prefix(hint) when is_list(hint), do: List.to_string(hint)
+
+  defp struct_prefix({:dot, {:alias, mod}, hint}),
+    do: List.to_string(mod) <> "." <> List.to_string(hint)
+
+  defp struct_prefix({:local_or_var, hint}), do: List.to_string(hint)
+  defp struct_prefix(_), do: nil
+
+  defp complete_struct(nil), do: []
+
+  defp complete_struct(prefix) do
+    specials =
+      if prefix == "",
+        do: [],
+        else: for(form <- @special_forms, String.starts_with?(form, prefix), do: "%" <> form)
+
+    modules =
+      for {module, _} <- :code.all_loaded(),
+          name = Atom.to_string(module),
+          String.starts_with?(name, "Elixir."),
+          short = String.replace_prefix(name, "Elixir.", ""),
+          String.starts_with?(short, prefix),
+          function_exported?(module, :__struct__, 1) do
+        "%" <> short
+      end
+
+    (specials ++ modules) |> Enum.sort()
   end
 
   defp resolve_alias(charlist) do


### PR DESCRIPTION
Code completion would fail on stuff like %__MODULE__

with an error like

```elixir
23:27:24.599 [error] #PID<0.264764.0> running GtBridge.Http.Router (connection #PID<0.264761.0>, stream id 1) terminated
Server: localhost:1212 (http)
Request: POST /COMPLETE
** (exit) exited in: GenServer.call(#PID<0.264748.0>, {:complete, "%__MODULE__", "@doc \"\"\"\nFork a command log\n\"\"\"\n@spec fork(non_neg_integer() | :tip, t()) :: t()\ndef fork(at \\\\ :tip, from = %__MODULE__{id: id} \\\\ head()) do\n  unless from == :main or from in list() do\n    raise ArgumentError, \"cannot fork from unknown branch \#{inspect(from)}\"\n  end\n\n  branch = %__MODULE__:\"fork_\#{System.unique_integer([:positive])}\"\n  AL.Command.create_tables(branch)\n  AL.Command.copy_prefix(from, branch, at_time(at))\n  AL.Object.create_tables(branch)\n  AL.Object.hydrate_since(0, branch)\n  register(branch, from)\n  AL.Scheduler.start(branch)\n  branch\n%__MODULE__"}, :infinity)
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in List.to_string/1
            (elixir 1.18.4) lib/list.ex:1119: List.to_string({:local_or_var, ~c"__MODULE__"})
            (gt_bridge 0.17.3) lib/gt_bridge/completion.ex:47: GtBridge.Completion.complete/4
            (gt_bridge 0.17.3) lib/gt_bridge/eval.ex:147: GtBridge.Eval.handle_call/3
            (stdlib 6.1) gen_server.erl:2381: :gen_server.try_handle_call/4
            (stdlib 6.1) gen_server.erl:2410: :gen_server.handle_msg/6
            (stdlib 6.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3

```

this patch seeks to rectify this issue